### PR TITLE
fix: handle missing release gracefully

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -22,10 +22,10 @@ runs:
       shell: bash
       run: |
         echo ${{ github.token }} | gh auth login --with-token
-        release="$(gh release list --limit 3 | grep "^${{ inputs.branch }}" | head -1 | awk '{print $1;}')"
+        release="$(gh release list --limit 3 | grep "^${{ inputs.branch }}" | head -1 | awk '{print $1;}' || true)"
         echo "release=${release}" >> $GITHUB_ENV
     - name: dispatch
-      if: ${{ inputs.dispatch-token != '' && inputs.dispatch-target != '' }}
+      if: ${{ env.release != '' && inputs.dispatch-token != '' && inputs.dispatch-target != '' }}
       uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4
       with:
         token: ${{ inputs.dispatch-token }}


### PR DESCRIPTION
## Summary
- Add `|| true` to the grep pipeline so the step doesn't fail when no release matches the target branch
- Skip the dispatch step when no release was found (empty `release` env var)

Fixes the issue where the submit action fails with exit code 1 when a repo has no releases matching the branch name (stable/testing/unstable).

## Test plan
- [ ] Verify the action no longer fails on repos without matching releases
- [ ] Verify the action still dispatches correctly when a matching release exists